### PR TITLE
CLOSES #33: Updates Fess to 12.1.1.

### DIFF
--- a/fess/Dockerfile
+++ b/fess/Dockerfile
@@ -1,6 +1,6 @@
 FROM centos:7.4.1708
 
-ARG FESS_VERSION="12.1.0"
+ARG FESS_VERSION="12.1.1"
 ARG FESS_FILENAME="fess-${FESS_VERSION}.zip"
 ARG FESS_RELEASE_URI="https://github.com/codelibs/fess/releases/download/fess-${FESS_VERSION}/${FESS_FILENAME}"
 


### PR DESCRIPTION
CLOSES #33

Fess [12.1.1](https://github.com/codelibs/fess/releases/tag/fess-12.1.1)